### PR TITLE
아이템 충돌이 인식되지 않는 버그 수정

### DIFF
--- a/Character.py
+++ b/Character.py
@@ -52,7 +52,7 @@ class Character(Object):
         if key_pressed[pygame.K_LEFT]:
             self.x -= self.velocity
             if self.x < 0:
-                self.x = 0
+                self.x = 0        
         if key_pressed[pygame.K_RIGHT]:
             self.x += self.velocity
             if self.x >= self.boundary[0] - self.sx:
@@ -99,6 +99,7 @@ class Character(Object):
                         self.img = self.img_copy
         else:
             self.img = self.img_copy
+        self.update_rect((self.x, self.y))
         # 화면 밖으로 나간 미사일 삭제
         for missile in list(self.missiles_fired):
             missile.update(game)

--- a/CharacterSelectMenu.py
+++ b/CharacterSelectMenu.py
@@ -57,7 +57,7 @@ class CharacterSelectMenu(pygame_menu.menu.Menu):
         self.character_selector = self.add.selector(
             title='Character :\t',
             items=characters,
-            onchange=self._on_selector_change
+            onchange=self.on_selector_change
         )
         self.image_widget = self.add.image(
             image_path=self.character_imgs[0],
@@ -68,19 +68,19 @@ class CharacterSelectMenu(pygame_menu.menu.Menu):
         self.frame_v = self.add.frame_v(350, 160, margin=(10, 0))
         self.power = self.frame_v.pack(self.add.progress_bar(
             title="Power",
-            default=int((self.character_data[0].missile_power/500)*100),
+            default=int((self.character_data[0].missile_power/Default.character.value["max_stats"]["power"])*100),
             progress_text_enabled = False,
             box_progress_color = Color.RED.value
         ), ALIGN_RIGHT)
         self.fire_rate = self.frame_v.pack(self.add.progress_bar(
             title="Fire Rate",
-            default=int((0.3/self.character_data[0].org_fire_interval)*100),
+            default=int((Default.character.value["max_stats"]["fire_rate"]/self.character_data[0].org_fire_interval)*100),
             progress_text_enabled = False,
             box_progress_color =Color.BLUE.value
         ), ALIGN_RIGHT)
         self.velocity = self.frame_v.pack(self.add.progress_bar(
             title="Mobility",
-            default=int((self.character_data[0].org_velocity/25)*100),
+            default=int((self.character_data[0].org_velocity/Default.character.value["max_stats"]["mobility"])*100),
             progress_text_enabled = False,
             box_progress_color = Color.GREEN.value
         ), ALIGN_RIGHT)
@@ -89,7 +89,7 @@ class CharacterSelectMenu(pygame_menu.menu.Menu):
         self.add.button("PLAY",self.start_game)
         # self.add.button("BACK",pygame_menu.events.BACK)
         self.add.button("BACK",self.to_menu)
-        self._update_from_selection(int(self.character_selector.get_value()[0][1]))
+        self.update_from_selection(int(self.character_selector.get_value()[0][1]))
 
 
     def start_game(self): #게임 시작 함수
@@ -166,25 +166,13 @@ class CharacterSelectMenu(pygame_menu.menu.Menu):
             self._current._widgets_surface = make_surface(0,0)
             print(f'New menu size: {self.get_size()}')
 
-    def _on_selector_change(self, selected, value: int) -> None:
-        """
-        Function executed if selector changes.
-        :param selected: Selector data containing text and index
-        :param value: Value from the selected option
-        :return: None
-        """
-        print('Selected data:', selected)
-        self._update_from_selection(value)
+    def on_selector_change(self, selected, value: int) -> None:
+        self.update_from_selection(value)
 
-    def _update_from_selection(self, selected_value, **kwargs) -> None:
-        """
-        Change widgets depending on index.
-        :param index: Index
-        :return: None
-        """
+    def update_from_selection(self, selected_value, **kwargs) -> None:
         self.current = selected_value
         self.image_widget.set_image(self.character_imgs[selected_value])
-        self.power.set_value(int((self.character_data[selected_value].missile_power/500)*100))
-        self.fire_rate.set_value(int((0.3/self.character_data[selected_value].org_fire_interval)*100))
-        self.velocity.set_value(int((self.character_data[selected_value].org_velocity/25)*100))
+        self.power.set_value(int((self.character_data[selected_value].missile_power/Default.character.value["max_stats"]["power"])*100))
+        self.fire_rate.set_value(int((Default.character.value["max_stats"]["fire_rate"]/self.character_data[selected_value].org_fire_interval)*100))
+        self.velocity.set_value(int((self.character_data[selected_value].org_velocity/Default.character.value["max_stats"]["mobility"])*100))
         self.item_description_widget.set_title(title = "Unlocked" if self.character_data[selected_value].is_unlocked == True else "Locked")

--- a/Defs.py
+++ b/Defs.py
@@ -59,7 +59,12 @@ class Default(enum.Enum):
             "speed":20,
             "volume":0.1,
             "speed_inc":1
-            }
+            },
+        "max_stats":{
+            "power":500,
+            "fire_rate":0.3,
+            "mobility":25
+        }
     }
     item = {
         "duration":10.0,

--- a/InfiniteGame.py
+++ b/InfiniteGame.py
@@ -190,7 +190,7 @@ class InfiniteGame:
                 bullet.show(self.screen)
 
             for item in list(self.item_list):
-                if(self.check_crash(self.character,item)):
+                if item.rect_collide(self.character.rect):
                     item.use(self)
 
             #발사체와 몹 충돌 감지

--- a/Item.py
+++ b/Item.py
@@ -36,7 +36,7 @@ class Item(Object):
             self.x_inv = True
         elif self.y >= self.boundary[1] - self.sy:
             self.y_inv = True
-        
+        self.update_rect((self.x, self.y))
         self.inc += Default.animation.value["speed"]
         self.inc = Utils.clamp(self.inc, 0.0, self.frame_count-1)
         if self.inc >= self.frame_count-1:

--- a/Object.py
+++ b/Object.py
@@ -12,6 +12,7 @@ class Object:
         self.size = size
         self.sx = size["x"]
         self.sy = size["y"]
+        self.rect = pygame.Rect(0, 0, self.sx, self.sy)
         self.velocity = velocity
         self.frames = frames
         self.frames_trans = frames_trans
@@ -48,10 +49,15 @@ class Object:
         else:
             self.img = self.frames[self.current_frame]
         self.sx, self.sy = self.img.get_size()
+        self.rect.size = (self.sx, self.sy)
 
     def set_XY(self,loc):
         self.x = loc[0]
         self.y = loc[1]
+        self.update_rect(loc)
+
+    def update_rect(self, loc):
+        self.rect.topleft = loc
 
     # 피사체의 그림 조정
     def change_size(self):
@@ -64,6 +70,7 @@ class Object:
         self.img_trans = self.img.copy()
         self.img_trans.fill(Color.TRANSPARENT.value, None, pygame.BLEND_RGBA_MULT)
         self.sx, self.sy = self.img.get_size()
+        self.rect.size = (self.sx, self.sy)
         if self.is_transparent:
             self.img = self.img_trans
         else:
@@ -84,6 +91,9 @@ class Object:
             return True
         else:
             return False
+
+    def rect_collide(self, rect):
+        return self.rect.colliderect(rect)
 
     #크기 조정 함수
     def on_resize(self, game):

--- a/StageGame.py
+++ b/StageGame.py
@@ -202,7 +202,7 @@ class StageGame:
                 bullet.show(self.screen)
 
             for item in list(self.item_list):
-                if(self.check_crash(self.character,item)):
+                if item.rect_collide(self.character.rect):
                     item.use(self)
 
 

--- a/characterdata.json
+++ b/characterdata.json
@@ -54,7 +54,7 @@
             "missile_sfx": "./Sound/weapon-sound8.wav",
             "missile_power": 450,
             "fire_interval": 0.6,
-            "is_unlocked": true
+            "is_unlocked": false
         },
         {
             "name": "F5S4",


### PR DESCRIPTION
내용:
캐릭터와 아이템에 적용되어 있는 깜빡임 애니메이션으로 인해 충돌이 인식되지 않는 버그 수정

발생 원인:
플레이어 캐릭터가 장애물과 충돌하면 깜빡임 애니메이션이 무적 기간 동안 일어난다.
아이템이 생성되고 일정 시간 동안 얻지 못하면 깜빡이면서 사라진다. 
깜빡임 애니메이션은 불투명한 이미지(알파값 255)와 투명한 이미지(알파값 128)가 번갈아 가면서 나타나는 방식으로 구현되어 있다. 
기존 충돌 감지 방식은 pygame.mask로 불투명한 픽셀만 인식하기 때문에 아이템과 캐릭터가 투명할 경우에 충돌이 인식되지 않는다. 

해결 방안:
캐릭터와 아이템 클래스에 pygame.rect 값을 추가해주고 각 객체가 이동할 때마다 사각형의 위치와 크기에 반영된다.
아이템과 캐릭터를 둘러싼 사각형이 서로 겹치면 충돌을 인식하도록 한다. 
사각형으로 충돌을 감지하면 사각형의 모서리가 겹치는 경우에도 충돌로 인식되기 때문에 기존 방식 보다 정확도가 떨어지지만 
캐릭터가 깜빡이는 경우에 아이템 충돌이 제대로 인식되지 않으면 게임 플레이에 영향을 미칠 수 있기 때문에 수정이 필요하다.