### PR TITLE
불필요한 코드 제거

### DIFF
--- a/menu/CharacterSelectMenu.py
+++ b/menu/CharacterSelectMenu.py
@@ -148,7 +148,6 @@ class CharacterSelectMenu(pygame_menu.menu.Menu):
             window_size = self.screen.get_size()
             new_w, new_h = 1 * window_size[0], 1 * window_size[1]
             self.resize(new_w, new_h)
-            self._build_widget_surface()
             self.size = window_size
             self._current._widgets_surface = make_surface(0,0)
             print(f'New menu size: {self.get_size()}')


### PR DESCRIPTION
캐릭터 선택 메뉴의 check_resize 함수에 있던
self._build_widget_surface()
코드를 지웠습니다.
해당 코드로 인해
게임 오버 후 돌아왔을 때 화면 리사이징 시
메뉴가 그려지지 않는 오류가 발생하는 듯 하여 제거 하였습니다.